### PR TITLE
Matter Megadrive compat

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -130,8 +130,8 @@ dependencies {
     //Nature's Compass 1.3.1
     compileOnly(deobfCurse("naturescompass-252848:2451823"))
 
-    //Netherlicious 3.2.3
-    compileOnly(deobfCurse("netherlicious-385860:3858031"))
+    //Netherlicious 3.2.8
+    compileOnly(deobfCurse("netherlicious-385860:4363437"))
 
     //Nomadic Tents 1.12.1
     compileOnly(deobfCurse("nomadictents-238794:2679476"))

--- a/src/main/java/com/falsepattern/endlessids/mixin/plugin/Mixin.java
+++ b/src/main/java/com/falsepattern/endlessids/mixin/plugin/Mixin.java
@@ -193,8 +193,8 @@ public enum Mixin implements IMixin {
     DragonAPIBlockItemIDTypeMixin(Side.COMMON, condition(() -> GeneralConfig.extendBlockItem).and(require(TargetedMod.DRAGONAPI)), "blockitem.dragonapi.IDTypeMixin"),
     //endregion DragonAPI
     //region Matter Overdrive
-    MOInventoryMixin(Side.COMMON, condition(() -> GeneralConfig.extendBlockItem).and(require(TargetedMod.MATTEROVERDRIVE)), "blockitem.matteroverdrive.InventoryMixin"),
-    MOItemPatternMixin(Side.COMMON, condition(() -> GeneralConfig.extendBlockItem).and(require(TargetedMod.MATTEROVERDRIVE)), "blockitem.matteroverdrive.ItemPatternMixin"),
+    MOInventoryMixin(Side.COMMON, condition(() -> GeneralConfig.extendBlockItem).and(require(TargetedMod.MATTEROVERDRIVE).or(require(TargetedMod.MATTEROVERDRIVE))), "blockitem.matteroverdrive.InventoryMixin"),
+    MOItemPatternMixin(Side.COMMON, condition(() -> GeneralConfig.extendBlockItem).and(require(TargetedMod.MATTEROVERDRIVE).or(require(TargetedMod.MATTEROVERDRIVE))), "blockitem.matteroverdrive.ItemPatternMixin"),
     //endregion Matter Overdrive
     //region MFQM
     MFQMMixin(Side.COMMON, condition(() -> GeneralConfig.extendBlockItem).and(require(TargetedMod.MFQM)), "blockitem.mfqm.MFQMMixin"),

--- a/src/main/java/com/falsepattern/endlessids/mixin/plugin/Mixin.java
+++ b/src/main/java/com/falsepattern/endlessids/mixin/plugin/Mixin.java
@@ -193,8 +193,8 @@ public enum Mixin implements IMixin {
     DragonAPIBlockItemIDTypeMixin(Side.COMMON, condition(() -> GeneralConfig.extendBlockItem).and(require(TargetedMod.DRAGONAPI)), "blockitem.dragonapi.IDTypeMixin"),
     //endregion DragonAPI
     //region Matter Overdrive
-    MOInventoryMixin(Side.COMMON, condition(() -> GeneralConfig.extendBlockItem).and(require(TargetedMod.MATTEROVERDRIVE).or(require(TargetedMod.MATTEROVERDRIVE))), "blockitem.matteroverdrive.InventoryMixin"),
-    MOItemPatternMixin(Side.COMMON, condition(() -> GeneralConfig.extendBlockItem).and(require(TargetedMod.MATTEROVERDRIVE).or(require(TargetedMod.MATTEROVERDRIVE))), "blockitem.matteroverdrive.ItemPatternMixin"),
+    MOInventoryMixin(Side.COMMON, condition(() -> GeneralConfig.extendBlockItem).and(require(TargetedMod.MATTEROVERDRIVE).or(require(TargetedMod.MATTERMEGADRIVE))), "blockitem.matteroverdrive.InventoryMixin"),
+    MOItemPatternMixin(Side.COMMON, condition(() -> GeneralConfig.extendBlockItem).and(require(TargetedMod.MATTEROVERDRIVE).or(require(TargetedMod.MATTERMEGADRIVE))), "blockitem.matteroverdrive.ItemPatternMixin"),
     //endregion Matter Overdrive
     //region MFQM
     MFQMMixin(Side.COMMON, condition(() -> GeneralConfig.extendBlockItem).and(require(TargetedMod.MFQM)), "blockitem.mfqm.MFQMMixin"),

--- a/src/main/java/com/falsepattern/endlessids/mixin/plugin/TargetedMod.java
+++ b/src/main/java/com/falsepattern/endlessids/mixin/plugin/TargetedMod.java
@@ -38,6 +38,7 @@ public enum TargetedMod implements ITargetedMod {
     IR3("Industrial Revolution by Redstone Rebooted", false, startsWith("industrialrevolutionbyredstonerebooted-")),
     LOTR("LOTR Mod", false, startsWith("lotrmod")),
     MATTEROVERDRIVE("Matter Overdrive", false, startsWith("matteroverdrive-")),
+    MATTERMEGADRIVE("Matter Megadrive", false, startsWith("mattermegadrive-")),
     MFQM("More Fun Quicksand Mod", false, startsWith("morefunquicksandmod-")),
     NATURESCOMPASS("Nature's Compass", false, startsWith("naturescompass")),
     NETHERLICIOUS("Netherlicious", false, startsWith("netherlicious-")),


### PR DESCRIPTION
### Changes:
* update Netherlicious in dependencies.gradle for correct build
* add support for Matter Megadrive - fork of Matter Overdrive, with bug fixes, new features, tweaks, etc.

Should™ work