### PR TITLE
Common IDExtender API

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -25,7 +25,7 @@ If you notice any problems when opening NEID worlds with EndlessIDs, please open
 | Entity IDs      | 256                                                | 256          | 256             | 32,768     |
 | Potion IDs      | 32                                                 | 32           | 32              | 65,536     |
 | Enchantment IDs | 256                                                | 256          | 256             | 32,768     |
-| DataWatcher IDs | 32                                                 | 127 (Broken) | 127 (Broken)    | 65,536     |
+| DataWatcher IDs | 32                                                 | 127 (Broken) | 127             | 65,536     |
 | Dimension IDs   | Theoretically unlimited, 4,294,967,295 in practice | Same         | Same            | Same       |
 
 ## Mod compat
@@ -134,6 +134,9 @@ if (Loader.isModLoaded("idextender")){
     metadataBits = (Integer) Class.forName("idextender.Metadata").getDeclaredMethod("metadataBits").invoke(null);
 }
 ```
+
+The `idextender.DataWatcher` class also exposes the extended DataWatcher count (used for entity data syncing over network)
+in a similar fashion.
 
 Note that these values CAN be identical to the vanilla values if the ID Extension mod implementing it has a config to
 toggle itself, existence of the IDExtender class does not guarantee a fixed increase, and you should check that the

--- a/README.MD
+++ b/README.MD
@@ -101,9 +101,9 @@ If you find any crashes or incompatibilities, don't hesitate to open an issue.
 
 ## Depending On Metadata Increase In Another Mod
 
-**NOTE:** This API is available as of version <!--TODO--> of EndlessIDs.
+**NOTE:** This API is available as of version TODO of EndlessIDs.
 
-EndlessIDs implements the common ID Extender API added in NotEnoughIDs Unofficial. See:
+EndlessIDs implements the common ID Extender API introduced in NotEnoughIDs Unofficial. See:
 https://github.com/GTNewHorizons/NotEnoughIds/pull/17
 
 The description below is an excerpt of NEID-U's readme concerning this API:
@@ -134,6 +134,10 @@ if (Loader.isModLoaded("idextender")){
     metadataBits = (Integer) Class.forName("idextender.Metadata").getDeclaredMethod("metadataBits").invoke(null);
 }
 ```
+
+Note that these values CAN be identical to the vanilla values if the ID Extension mod implementing it has a config to
+toggle itself, existence of the IDExtender class does not guarantee a fixed increase, and you should check that the
+returned value is large enough for your needs. 
 
 If for some reason, you need to know what parent mod is providing the `idextender` mod, you can do the following, which will give you
 back the Mod ID of the actual mod that has provided `idextender`. For example, `endlessids`:

--- a/README.MD
+++ b/README.MD
@@ -98,3 +98,49 @@ Mods not listed here may or may not work.
 user to this GitHub repo.
 
 If you find any crashes or incompatibilities, don't hesitate to open an issue.
+
+## Depending On Metadata Increase In Another Mod
+
+**NOTE:** This API is available as of version <!--TODO--> of EndlessIDs.
+
+EndlessIDs implements the common ID Extender API added in NotEnoughIDs Unofficial. See:
+https://github.com/GTNewHorizons/NotEnoughIds/pull/17
+
+The description below is an excerpt of NEID-U's readme concerning this API:
+
+In order to use the metadata, you should not create a hard dependency on the `endlessids` Mod ID, but rather on the `idextender` Mod ID.
+EndlessIDs bundles this "dummy" mod alongside itself.
+
+Here is an example of how to use it, you could put this code in your Mod's pre-init for example:
+
+```java
+import idextender;
+
+int maxMeta = 15;
+
+if (Loader.isModLoaded("idextender")) {
+    maxMeta = (Integer) Class.forName("idextender.Metadata").getDeclaredMethod("maximumMetadata").invoke(null);
+}
+```
+
+You can also query for the number of bits the metadata value is extended to, rather than the maximum value:
+
+```java
+import idextender;
+
+int metadataBits = 4;
+
+if (Loader.isModLoaded("idextender")){
+    metadataBits = (Integer) Class.forName("idextender.Metadata").getDeclaredMethod("metadataBits").invoke(null);
+}
+```
+
+If for some reason, you need to know what parent mod is providing the `idextender` mod, you can do the following, which will give you
+back the Mod ID of the actual mod that has provided `idextender`. For example, `endlessids`:
+
+```java
+// This will give back the value "endlessids" which is EndlessIDs' Mod ID
+String parentIDExtender = (String) Class.forName("idextender.IDExtender").getDeclaredMethod("parentModId").invoke(null);
+```
+
+For more information, see the NotEnoughIDs readme.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,11 @@ minecraft_fp {
         rootPkg = "$group.endlessids"
     }
 
+    api {
+        packages = listOf("idextender")
+        ignoreRootPkg = true
+    }
+
     mixin {
         pkg = "mixin.mixins"
         pluginClass = "mixin.plugin.MixinPlugin"

--- a/src/main/java/com/falsepattern/endlessids/constants/ExtendedConstants.java
+++ b/src/main/java/com/falsepattern/endlessids/constants/ExtendedConstants.java
@@ -58,6 +58,9 @@ public class ExtendedConstants {
     public static final int itemIDCount = 1 << (bitsPerID - countCorrectionItemBits);
     public static final int maxItemID = itemIDCount - 1;
 
+    public static final int metadataCount = (1 << bitsPerMetadata);
+    public static final int maxMetadata = metadataCount - 1;
+
     public static final int bitsPerBlock = 8 + bitsPerID + bitsPerMetadata;
     public static final int nibblesPerBlock = bitsPerBlock / 4;
     public static final int nibblesPerSubChunk = nibblesPerBlock * 16 * 16 * 16;

--- a/src/main/java/com/falsepattern/endlessids/constants/VanillaConstants.java
+++ b/src/main/java/com/falsepattern/endlessids/constants/VanillaConstants.java
@@ -48,6 +48,9 @@ public class VanillaConstants {
     public static final int itemIDCount = 32000;
     public static final int maxItemID = itemIDCount - 1;
 
+    public static final int metadataCount = (1 << bitsPerMetadata);
+    public static final int maxMetadata = metadataCount - 1;
+
     public static final int bitsPerBlock = 8 + bitsPerID + bitsPerMetadata;
     public static final int nibblesPerBlock = bitsPerBlock / 4;
     public static final int nibblesPerSubChunk = nibblesPerBlock * 16 * 16 * 16;

--- a/src/main/java/idextender/DataWatcher.java
+++ b/src/main/java/idextender/DataWatcher.java
@@ -1,0 +1,16 @@
+package idextender;
+
+import com.falsepattern.endlessids.config.GeneralConfig;
+import com.falsepattern.endlessids.constants.ExtendedConstants;
+import com.falsepattern.endlessids.constants.VanillaConstants;
+
+public class DataWatcher {
+    public static int maxWatchableID() {
+        return GeneralConfig.extendDataWatcher ? ExtendedConstants.maxWatchableID : VanillaConstants.maxWatchableID;
+    }
+
+    public static int watchableBits() {
+        return GeneralConfig.extendDataWatcher ? ExtendedConstants.watchableBits : VanillaConstants.watchableBits;
+    }
+
+}

--- a/src/main/java/idextender/IDExtender.java
+++ b/src/main/java/idextender/IDExtender.java
@@ -1,0 +1,14 @@
+package idextender;
+
+import com.falsepattern.endlessids.Tags;
+
+import cpw.mods.fml.common.Mod;
+
+@Mod(modid = "idextender", name = "ID Extender", version = "1.0.0")
+public class IDExtender {
+
+    public static String parentModId() {
+        return Tags.MODID;
+    }
+
+}

--- a/src/main/java/idextender/Metadata.java
+++ b/src/main/java/idextender/Metadata.java
@@ -1,0 +1,16 @@
+package idextender;
+
+import com.falsepattern.endlessids.config.GeneralConfig;
+import com.falsepattern.endlessids.constants.ExtendedConstants;
+import com.falsepattern.endlessids.constants.VanillaConstants;
+
+public class Metadata {
+    public static int maximumMetadata() {
+        return GeneralConfig.extendBlockItem ? ExtendedConstants.maxMetadata : VanillaConstants.maxMetadata;
+    }
+
+    public static int metadataBits() {
+        return GeneralConfig.extendBlockItem ? ExtendedConstants.bitsPerMetadata : VanillaConstants.bitsPerMetadata;
+    }
+
+}

--- a/src/main/java/idextender/package-info.java
+++ b/src/main/java/idextender/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Interop with NEID Unofficial, to let mods avoid hard-depending on either NEIDu or EndlessIDs
+ */
+package idextender;

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -14,5 +14,11 @@
     "logoFile": "",
     "screenshots": [],
     "dependencies": []
+  },
+  {
+    "modid": "idextender",
+    "name": "ID Extender",
+    "version": "1.0.0",
+    "parent": "${modId}"
   }
 ]


### PR DESCRIPTION
This PR implements a common API to allow mods to use both NEID and EndlessIDs when they require extended values natively.

For more information, see: https://github.com/GTNewHorizons/NotEnoughIds/pull/17