### PR TITLE
Fix (rare) crash with RTG

### DIFF
--- a/src/main/java/com/falsepattern/endlessids/mixin/mixins/common/biome/rtg/WorldChunkManagerRTGMixin.java
+++ b/src/main/java/com/falsepattern/endlessids/mixin/mixins/common/biome/rtg/WorldChunkManagerRTGMixin.java
@@ -25,12 +25,28 @@ package com.falsepattern.endlessids.mixin.mixins.common.biome.rtg;
 import com.falsepattern.endlessids.constants.ExtendedConstants;
 import com.falsepattern.endlessids.constants.VanillaConstants;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyConstant;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import rtg.world.biome.WorldChunkManagerRTG;
 
 @Mixin(WorldChunkManagerRTG.class)
 public abstract class WorldChunkManagerRTGMixin {
+    
+    @Shadow(remap = false)
+    private float[] borderNoise;
+
+    @Inject(method = "<init>()V",
+            at = @At(value = "RETURN"),
+            require = 1,
+            remap = false)
+    private void extendBorderNoise(CallbackInfo ci) {
+        this.borderNoise = new float[ExtendedConstants.biomeIDCount];
+    }
+    
     @ModifyConstant(method = "getRainfall",
                     constant = @Constant(intValue = VanillaConstants.biomeIDMask),
                     require = 2)


### PR DESCRIPTION
In rare cases, a certain section of RTG terrain would crash with the error `java.lang.ArrayIndexOutOfBoundsException: Index 5063 out of bounds for length 256` (which, in fact, "soft blocked" save (every attempt to enter the world - crash))

The error occurred in `WorldChunkManagerRTG.isBorderlessAt`:

```java

protected WorldChunkManagerRTG() {
    this.borderNoise = new float[256];
    ...
}

public boolean isBorderlessAt(int x, int y) {
   ...
    for (bx = -2; bx <= 2; bx++) {
        for (by = -2; by <= 2; by++) {
            borderNoise[getBiomeDataAt(x + bx * 16, y + by * 16).baseBiome.biomeID] += 0.04f;
        }
    }
   ...
}
```

Where, somehow, `getBiomeDataAt(x + bx * 16, y + by * 16).baseBiome.biomeID` was 5063 (btw, I don’t have a single biome with such id), but borderNoise was initialized with 256

So I added a borderNoise extension to the mixin, similar to the one in ChunkProviderRTG

After the change I was able to enter the world. No generation bugs/repeated crashes were noticed